### PR TITLE
disable addon on secure screens

### DIFF
--- a/addon/globalPlugins/EnhancedDictionaries/__init__.py
+++ b/addon/globalPlugins/EnhancedDictionaries/__init__.py
@@ -35,6 +35,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def __init__(self, *args, **kwargs):
 		super(GlobalPlugin, self).__init__(*args, **kwargs)
+		if globalVars.appArgs.secure:
+			log.info("EnhancedDictionaries addon will not activate on secure screens")
+			return
 		self.injectProcessing()
 	
 	# the method below is responsible for modifying NVDA behavior.

--- a/buildVars.py
+++ b/buildVars.py
@@ -22,7 +22,7 @@ addon_info = {
     "addon_description": _("""This addon introduces better dictionaries handling for NVDA.
 It is now possible to use profile specific dictionaries, which eenables better productivity by allowing you to use different dictionaries for different applications and scenarius."""),
     # version
-    "addon_version": "1.2.0",
+    "addon_version": "1.2.1",
     # Author(s)
     "addon_author": u"Marlon Brandão de Sousa <marlon.bsousa@gmail.com>",
     # URL for the add-on documentation support

--- a/localdeploy.bat
+++ b/localdeploy.bat
@@ -1,0 +1,5 @@
+@echo off
+rem obtaining addon name, the current directory name
+for %%f in (%cd%) do set addon=%%~nxf
+rem copying addon files to local nvda addon directory
+robocopy /S addon %appdata%\nvda\addons\%addon%


### PR DESCRIPTION
This PR disables the addon loading in secure screens, cinse all dictionaries with the exception of tenporaries are disabled.

This also fixes #4  because, as we have no profiles being returned on secure screens, the whole addon was failing, causing breakage on menu loads.