### PR TITLE
Ci/release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,15 @@ jobs:
         uses: ericcornelissen/git-tag-annotation-action@v2
         id: tag-data
       - name: Make sure this tag is applied on top of master branch
+        id: differences-to-master
         run: |
-          if git diff master --exit-code; then
-            echo "::set-env name=changes_exist::false"
+          if git diff origin/master --exit-code; then
+            echo "::set-output name=changes_exist::false"
           else
-            echo "::set-env name=changes_exist::true"
+            echo "::set-output name=changes_exist::true"
           fi
       - name: abort if tag is not applied on top of master
-        if: "env.changes_exist == 'true'"
+        if: "${{ steps.differences-to-master.outputs.changes_exist }} == 'true'"
         uses: actions/github-script@v3
         with:
             script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Obtain tag message
         uses: ericcornelissen/git-tag-annotation-action@v2
         id: tag-data
+      - name: install system dependencies
+        run: sudo apt install gettext
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -21,7 +23,7 @@ jobs:
           # In this addon context it is really not important, as packaging should not deppend on architecture versions
           # However, for future NVDA related actions we might have to switch to windows runners
           python-version: '3.7'
-      - name: install dependencies
+      - name: install python dependencies
         run: |
           pip install scons
           pip install markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: *.nvda-addon
-          body: "${{ steps.tag-data.outputs.git-tag-annotation }}
+          files: '*.nvda-addon'
+          body: "${{ steps.tag-data.outputs.git-tag-annotation }}"
           fail_on_unmatched_files: true
           target_commitish: "ci/release-workflow"
           generate_release_notes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,5 @@ jobs:
           files: '*.nvda-addon'
           body: "${{ steps.tag-data.outputs.git-tag-annotation }}"
           fail_on_unmatched_files: true
-          target_commitish: "ci/release-workflow"
           generate_release_notes: false
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - run: echo the tag message is "${{ steps.tag-data.outputs.git-tag-annotation }}"
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,19 @@ jobs:
       - name: Obtain tag message
         uses: ericcornelissen/git-tag-annotation-action@v2
         id: tag-data
+      - name: Make sure this tag is applied on top of master branch
+        run: |
+          if git diff master --exit-code; then
+            echo "::set-env name=changes_exist::false"
+          else
+            echo "::set-env name=changes_exist::true"
+          fi
+      - name: abort if tag is not applied on top of master
+        if: "env.changes_exist == 'true'"
+        uses: actions/github-script@v3
+        with:
+            script: |
+              core.setFailed('Releases can be generated only from commit on head of master branch')
       - name: install system dependencies
         run: sudo apt install gettext
       - name: Install python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Obtain tag message
         uses: ericcornelissen/git-tag-annotation-action@v2
         id: tag-data
-      - name: Make sure this tag is applied on top of master branch
+      - name: Check differences to master branch
         id: differences-to-master
         run: |
           if git diff origin/master --exit-code; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: EnhancedFindDialogCI
-on: [push]
+on:
+  - push
 jobs:
-  Release-addon:
-    runs-on: ubuntu-latest
+  Release_addon:
+    runs-on: "ubuntu-latest"
     steps:
       - name: Obtain tag message
         uses: ericcornelissen/git-tag-annotation-action@v2
@@ -13,7 +14,7 @@ jobs:
       # see https://github.com/actions/checkout/issues/290
       - name: make sure we have the correct tag information
         run: git fetch --tags --force
-      -name: Install python
+      - name: Install python
         uses: actions/setup-python@v4
         with:
           python-version: '3.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: EnhancedFindDialogCI
 on:
-  - push
+  push:
+    tags:
+      - "**"
 jobs:
   Release_addon:
     runs-on: "ubuntu-latest"
@@ -28,7 +30,17 @@ jobs:
           pip install scons
           pip install markdown
       - name: generate addon
-        run: scons
+        run: |
+          rm *.nvda-addon
+          scons
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: *.nvda-addon
+          body: "${{ steps.tag-data.outputs.git-tag-annotation }}
+          fail_on_unmatched_files: true
+          target_commitish: "ci/release-workflow"
+          generate_release_notes: false
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
+          # it seems that x86 versions of python 3 are not available for linux install.
+          # In this addon context it is really not important, as packaging should not deppend on architecture versions
+          # However, for future NVDA related actions we might have to switch to windows runners
           python-version: '3.7'
-          architecture: 'x86'
       - name: install dependencies
         run: |
           pip install scons

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           pip install markdown
       - name: generate addon
         run: |
-          rm *.nvda-addon
+          rm -f *.nvda-addon || true
           scons
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         run: |
           pip install scons
           pip install markdown
+      - name: generate addon
+        run: scons
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: EnhancedFindDialogCI
+on: [push]
+jobs:
+  Release-addon:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Obtain tag message
+        uses: ericcornelissen/git-tag-annotation-action@v2
+        id: tag-data
+      - name: Checkout code
+        uses: actions/checkout@v3
+      # The next step is used to fix a small issue here to obtain the current tag message, which will be used as the release body. For more details
+      # see https://github.com/actions/checkout/issues/290
+      - name: make sure we have the correct tag information
+        run: git fetch --tags --force
+      -name: Install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+          architecture: 'x86'
+      - name: install dependencies
+        run: |
+          pip install scons
+          pip install markdown
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - run: echo the tag message is "${{ steps.tag-data.outputs.git-tag-annotation }}"
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,15 @@ jobs:
   Release_addon:
     runs-on: "ubuntu-latest"
     steps:
-      - name: Obtain tag message
-        uses: ericcornelissen/git-tag-annotation-action@v2
-        id: tag-data
       - name: Checkout code
         uses: actions/checkout@v3
       # The next step is used to fix a small issue here to obtain the current tag message, which will be used as the release body. For more details
       # see https://github.com/actions/checkout/issues/290
       - name: make sure we have the correct tag information
         run: git fetch --tags --force
+      - name: Obtain tag message
+        uses: ericcornelissen/git-tag-annotation-action@v2
+        id: tag-data
       - name: Install python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
In this pr we inmplement a continuous integration and continuous delivery process that will generate a new release of this addon when a tag is applied on top of the commit at the head of master branch.

This complements the automated readme.md generation which already points the download link to a release according to the new version, but this release needed to be manually generated before.

Although we could extract the new version from build_vars.py and generate the tag and release in one process, this would cause other issues, such as trying to generate a release on commits to master which do not necessarily are intended to generate releases, such as documentation fixes or other kinds of changes.

This finds a good balance between control and authomated process, requiring that should a release de needed the only thing one has to do is generating a tag with the name equals to the version pointed on build_vars.py and the rest will work.