### PR TITLE
Automatic importing from default dictionary when profile dictionary is loaded

### DIFF
--- a/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
@@ -10,164 +10,155 @@ from logHandler import log
 import speechDictHandler
 from speechDictHandler import dictFormatUpgrade, dictionaries
 import os
+from . import profileConfigurationHelper
 
 
 # we need to inject these methods in speechDictHandler.SpeechDict class
-# they will be used to sync with other dictionaries and to create new dictionaries
+# they will be used to sync with other dictionaries
+# and to create new dictionaries
 # and will be called inside the dictionary dialog
 def patchSpeechDict():
-	speechDictHandler.SpeechDict.create = create
-	speechDictHandler.SpeechDict.syncFrom = syncFrom
-
-
-def stringToBool(string):
-	if string == 'True':
-		return True
-	return False
+    speechDictHandler.SpeechDict.create = create
+    speechDictHandler.SpeechDict.syncFrom = syncFrom
 
 
 def create(self, fileName):
-	if os.path.exists(fileName):
-		raise f"can not create dictionary backed by file {fileName}"
-	self.fileName = fileName
-	log.debug("creating dictionary with file '%s'." % fileName)
+    if os.path.exists(fileName):
+        raise f"can not create dictionary backed by file {fileName}"
+    self.fileName = fileName
+    log.debug("creating dictionary with file '%s'." % fileName)
 
 
 def syncFrom(self, source):
-	for entry in source:
-		if not next((x for x in self if x.pattern == entry.pattern), None):
-			self.append(entry)
+    for entry in source:
+        if not next((x for x in self if x.pattern == entry.pattern), None):
+            self.append(entry)
 
 
 # the functions below would be inserted right in speechDictHandler module
 # as they are specific for this addon, we don't need to inject them.
 # We will ratter use them right from this module
 def reloadDictionaries():
-	from synthDriverHandler import getSynth
-	synth = getSynth()
-	module = 'EnhancedDictionaries'
-	key = 'keepUpdatedCheckbox'
-	profileConfig = config.conf[module][key]
+    from synthDriverHandler import getSynth
+    synth = getSynth()
+    loadProfileDict()
+    loadVoiceDict(synth)
+    profileName = config.conf.getActiveProfile().name
 
-	loadProfileDict()
-	loadVoiceDict(synth)
-	profileName = config.conf.getActiveProfile().name
+    if profileConfigurationHelper.getSavedCheckboxValueForProfile():
+        sourceFileName = os.path.join(WritePaths.speechDictsDir, "default.dic")
+        source = speechDictHandler.SpeechDict()
+        source.load(sourceFileName)
 
-	if stringToBool(profileConfig):
-		sourceFileName = os.path.join(WritePaths.speechDictsDir, "default.dic")
-		source = speechDictHandler.SpeechDict()
-		source.load(sourceFileName)
+        activeDict = getDictionary("default")
+        activeDict.syncFrom(source)
 
-		activeDict = getDictionary("default")
-		activeDict.syncFrom(source)
-
-		voiceDict = getDictionary("voice")
-		voiceDict.syncFrom(source)
-
-		log.debug(f"Saving and activating updated dictionaries for profile {profileName}")
-		for dictType in ["default", "voice"]:
-			dictionaries[dictType].save()
-	log.debug(f"loaded dictionaries for profile {profileName or 'default'}")
+        voiceDict = getDictionary("voice")
+        voiceDict.syncFrom(source)
+        log.debug(f"Saving and activating updated dictionaries for profile {profileName}")
+        for dictType in ["default", "voice"]:
+            dictionaries[dictType].save()
+    log.debug(f"loaded dictionaries for profile {profileName or 'default'}")
 
 
 def _getVoiceDictionary(profile):
-	from synthDriverHandler import getSynth
-	synth = getSynth()
-	dictionaryFilename = _getVoiceDictionaryFileName(synth)
-	# if we are om default profile or the specific dictionary profile is already loaded
-	if not profile.name or _hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFilename):
-		# we are with the correct dictionary loaded. Just return it.
-		log.debug(f"Voice dictionary, backed by {dictionaries['voice'].fileName} was requested")
-		return dictionaries["voice"]
-	# we are on a user profile for which there is no dictionary created for the current voice.
-	# The current loaded dictionary is the default profile one.
-	# As we have beem called to get the profile dictionary for the current voice and it still does not exist,
-	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
-	# This is a task the caller should do when and if they wish
-	dic = speechDictHandler.SpeechDict()
-	dic.create(os.path.join(getProfileVoiceDictsPath(), synth.name, dictionaryFilename))
-	log.debug(
-		f"voice dictionary was requested for profile {profile.name}, but the backing file does not exist."
-		f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
-	)
-	return dic
+    from synthDriverHandler import getSynth
+    synth = getSynth()
+    dictionaryFilename = _getVoiceDictionaryFileName(synth)
+    # if we are om default profile or the specific dictionary profile is already loaded
+    if not profile.name or _hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFilename):
+        # we are with the correct dictionary loaded. Just return it.
+        log.debug(f"Voice dictionary, backed by {dictionaries['voice'].fileName} was requested")
+        return dictionaries["voice"]
+    # we are on a user profile for which there is no dictionary created for the current voice.
+    # The current loaded dictionary is the default profile one.
+    # As we have beem called to get the profile dictionary for the current voice and it still does not exist,
+    # We will create it now and pass the new, empty dictionary to the caller, but won't save it.
+    # This is a task the caller should do when and if they wish
+    dic = speechDictHandler.SpeechDict()
+    dic.create(os.path.join(getProfileVoiceDictsPath(), synth.name, dictionaryFilename))
+    log.debug(
+        f"voice dictionary was requested for profile {profile.name}, but the backing file does not exist."
+        f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
+    )
+    return dic
 
 
 def getDictionary(type):
-	profile = config.conf.getActiveProfile()
-	if(type == "voice"):
-		return _getVoiceDictionary(profile)
-	# if we are om default profile or the specific dictionary profile is already loaded
-	if not profile.name or _hasDictionaryProfile(profile.name, f"{type}.dic"):
-		# we are with the correct dictionary loaded. Just return it.
-		log.debug(f"{type} dictionary, backed by {dictionaries[type].fileName} was requested")
-		return dictionaries[type]
-	# we are on a user profile for which there is no dictionary created.
-	# The current loaded dictionary is the default profile one.
-	# As we have beem called to get the current profile dictionary and it still does not exist,
-	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
-	# This is a task the caller should do when and if they wish
-	dic = speechDictHandler.SpeechDict()
-	dic.create(os.path.join(WritePaths.speechDictsDir, profile.name, f"{type}.dic"))
-	log.debug(
-		f"{type} dictionary was requested for profile {profile.name}, but the backing file does not exist."
-		f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
-	)
-	return dic
+    profile = config.conf.getActiveProfile()
+    if(type == "voice"):
+        return _getVoiceDictionary(profile)
+    # if we are om default profile or the specific dictionary profile is already loaded
+    if not profile.name or _hasDictionaryProfile(profile.name, f"{type}.dic"):
+        # we are with the correct dictionary loaded. Just return it.
+        log.debug(f"{type} dictionary, backed by {dictionaries[type].fileName} was requested")
+        return dictionaries[type]
+    # we are on a user profile for which there is no dictionary created.
+    # The current loaded dictionary is the default profile one.
+    # As we have beem called to get the current profile dictionary and it still does not exist,
+    # We will create it now and pass the new, empty dictionary to the caller, but won't save it.
+    # This is a task the caller should do when and if they wish
+    dic = speechDictHandler.SpeechDict()
+    dic.create(os.path.join(WritePaths.speechDictsDir, profile.name, f"{type}.dic"))
+    log.debug(
+        f"{type} dictionary was requested for profile {profile.name}, but the backing file does not exist."
+        f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
+    )
+    return dic
 
 
 def loadProfileDict():
-	profile = config.conf.getActiveProfile()
-	if _hasDictionaryProfile(profile.name, "default.dic"):
-		_loadProfileDictionary(dictionaries["default"], profile.name, "default.dic")
-	else:
-		dictionaries["default"].load(os.path.join(WritePaths.speechDictsDir, "default.dic"))
-	dictionaries["builtin"].load("builtin.dic")
+    profile = config.conf.getActiveProfile()
+    if _hasDictionaryProfile(profile.name, "default.dic"):
+        _loadProfileDictionary(dictionaries["default"], profile.name, "default.dic")
+    else:
+        dictionaries["default"].load(os.path.join(WritePaths.speechDictsDir, "default.dic"))
+    dictionaries["builtin"].load("builtin.dic")
 
 
 def loadVoiceDict(synth):
-	"""Loads appropriate dictionary for the given synthesizer.
+    """Loads appropriate dictionary for the given synthesizer.
 It handles case when the synthesizer doesn't support voice setting.
 """
-	dictionaryFileName = _getVoiceDictionaryFileName(synth)
-	profile = config.conf.getActiveProfile()
-	if(_hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFileName)):
-		_loadProfileVoiceDictionary(dictionaries["voice"], synth.name, dictionaryFileName)
-	else:
-		fileName = os.path.join(WritePaths.voiceDictsDir, synth.name, dictionaryFileName)
-		dictionaries["voice"].load(fileName)
+    dictionaryFileName = _getVoiceDictionaryFileName(synth)
+    profile = config.conf.getActiveProfile()
+    if(_hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFileName)):
+        _loadProfileVoiceDictionary(dictionaries["voice"], synth.name, dictionaryFileName)
+    else:
+        fileName = os.path.join(WritePaths.voiceDictsDir, synth.name, dictionaryFileName)
+        dictionaries["voice"].load(fileName)
 
 
 def _getVoiceDictionaryFileName(synth):
-	try:
-		dictFormatUpgrade.doAnyUpgrades(synth)
-	except Exception:
-		log.error("error trying to upgrade dictionaries", exc_info=True)
-		pass
-	if synth.isSupported("voice"):
-		voice = synth.availableVoices[synth.voice].displayName
-		baseName = dictFormatUpgrade.createVoiceDictFileName(synth.name, voice)
-	else:
-		baseName = r"{synth}.dic".format(synth=synth.name)
-	return baseName
+    try:
+        dictFormatUpgrade.doAnyUpgrades(synth)
+    except Exception:
+        log.error("error trying to upgrade dictionaries", exc_info=True)
+        pass
+    if synth.isSupported("voice"):
+        voice = synth.availableVoices[synth.voice].displayName
+        baseName = dictFormatUpgrade.createVoiceDictFileName(synth.name, voice)
+    else:
+        baseName = r"{synth}.dic".format(synth=synth.name)
+    return baseName
 
 
 def _hasDictionaryProfile(profileName, dictionaryName):
-	return os.path.exists(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
+    return os.path.exists(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
 
 
 def getProfileVoiceDictsPath():
-	profile = config.conf.getActiveProfile()
-	return os.path.join(WritePaths.speechDictsDir, profile.name or "", r"voiceDicts.v1")
+    profile = config.conf.getActiveProfile()
+    return os.path.join(WritePaths.speechDictsDir, profile.name or "", r"voiceDicts.v1")
 
 
 def _hasVoiceDictionaryProfile(profileName, synthName, voiceName):
-	return os.path.exists(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))
+    return os.path.exists(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))
 
 
 def _loadProfileDictionary(target, profileName, dictionaryName):
-	target.load(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
+    target.load(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
 
 
 def _loadProfileVoiceDictionary(target, synthName, voiceName):
-	target.load(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))
+    target.load(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))

--- a/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
@@ -18,150 +18,150 @@ from . import profileConfigurationHelper
 # and to create new dictionaries
 # and will be called inside the dictionary dialog
 def patchSpeechDict():
-    speechDictHandler.SpeechDict.create = create
-    speechDictHandler.SpeechDict.syncFrom = syncFrom
+	speechDictHandler.SpeechDict.create = create
+	speechDictHandler.SpeechDict.syncFrom = syncFrom
 
 
 def create(self, fileName):
-    if os.path.exists(fileName):
-        raise f"can not create dictionary backed by file {fileName}"
-    self.fileName = fileName
-    log.debug("creating dictionary with file '%s'." % fileName)
+	if os.path.exists(fileName):
+		raise f"can not create dictionary backed by file {fileName}"
+	self.fileName = fileName
+	log.debug("creating dictionary with file '%s'." % fileName)
 
 
 def syncFrom(self, source):
-    for entry in source:
-        if not next((x for x in self if x.pattern == entry.pattern), None):
-            self.append(entry)
+	for entry in source:
+		if not next((x for x in self if x.pattern == entry.pattern), None):
+			self.append(entry)
 
 
 # the functions below would be inserted right in speechDictHandler module
 # as they are specific for this addon, we don't need to inject them.
 # We will ratter use them right from this module
 def reloadDictionaries():
-    from synthDriverHandler import getSynth
-    synth = getSynth()
+	from synthDriverHandler import getSynth
+	synth = getSynth()
 
-    loadProfileDict()
-    loadVoiceDict(synth)
-    profileName = config.conf.getActiveProfile().name
+	loadProfileDict()
+	loadVoiceDict(synth)
+	profileName = config.conf.getActiveProfile().name
 
-    if profileConfigurationHelper.getSavedCheckboxValueForProfile():
-        sourceFileName = os.path.join(WritePaths.speechDictsDir, "default.dic")
-        source = speechDictHandler.SpeechDict()
-        source.load(sourceFileName)
+	if profileConfigurationHelper.getSavedCheckboxValueForProfile():
+		sourceFileName = os.path.join(WritePaths.speechDictsDir, "default.dic")
+		source = speechDictHandler.SpeechDict()
+		source.load(sourceFileName)
 
-        activeDict = getDictionary("default")
-        activeDict.syncFrom(source)
+		activeDict = getDictionary("default")
+		activeDict.syncFrom(source)
 
-        voiceDict = getDictionary("voice")
-        voiceDict.syncFrom(source)
+		voiceDict = getDictionary("voice")
+		voiceDict.syncFrom(source)
 
-        log.debug(f"Saving and activating updated dictionaries for profile {profileName}")
-        for dictType in ["default", "voice"]:
-            dictionaries[dictType].save()
-    log.debug(f"loaded dictionaries for profile {profileName or 'default'}")
+		log.debug(f"Saving and activating updated dictionaries for profile {profileName}")
+		for dictType in ["default", "voice"]:
+			dictionaries[dictType].save()
+	log.debug(f"loaded dictionaries for profile {profileName or 'default'}")
 
 
 def _getVoiceDictionary(profile):
-    from synthDriverHandler import getSynth
-    synth = getSynth()
-    dictionaryFilename = _getVoiceDictionaryFileName(synth)
-    # if we are om default profile or the specific dictionary profile is already loaded
-    if not profile.name or _hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFilename):
-        # we are with the correct dictionary loaded. Just return it.
-        log.debug(f"Voice dictionary, backed by {dictionaries['voice'].fileName} was requested")
-        return dictionaries["voice"]
-    # we are on a user profile for which there is no dictionary created for the current voice.
-    # The current loaded dictionary is the default profile one.
-    # As we have beem called to get the profile dictionary for the current voice and it still does not exist,
-    # We will create it now and pass the new, empty dictionary to the caller, but won't save it.
-    # This is a task the caller should do when and if they wish
-    dic = speechDictHandler.SpeechDict()
-    dic.create(os.path.join(getProfileVoiceDictsPath(), synth.name, dictionaryFilename))
-    log.debug(
-        f"voice dictionary was requested for profile {profile.name}, but the backing file does not exist."
-        f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
-    )
-    return dic
+	from synthDriverHandler import getSynth
+	synth = getSynth()
+	dictionaryFilename = _getVoiceDictionaryFileName(synth)
+	# if we are om default profile or the specific dictionary profile is already loaded
+	if not profile.name or _hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFilename):
+		# we are with the correct dictionary loaded. Just return it.
+		log.debug(f"Voice dictionary, backed by {dictionaries['voice'].fileName} was requested")
+		return dictionaries["voice"]
+	# we are on a user profile for which there is no dictionary created for the current voice.
+	# The current loaded dictionary is the default profile one.
+	# As we have beem called to get the profile dictionary for the current voice and it still does not exist,
+	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
+	# This is a task the caller should do when and if they wish
+	dic = speechDictHandler.SpeechDict()
+	dic.create(os.path.join(getProfileVoiceDictsPath(), synth.name, dictionaryFilename))
+	log.debug(
+		f"voice dictionary was requested for profile {profile.name}, but the backing file does not exist."
+		f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
+	)
+	return dic
 
 
 def getDictionary(type):
-    profile = config.conf.getActiveProfile()
-    if(type == "voice"):
-        return _getVoiceDictionary(profile)
-    # if we are om default profile or the specific dictionary profile is already loaded
-    if not profile.name or _hasDictionaryProfile(profile.name, f"{type}.dic"):
-        # we are with the correct dictionary loaded. Just return it.
-        log.debug(f"{type} dictionary, backed by {dictionaries[type].fileName} was requested")
-        return dictionaries[type]
-    # we are on a user profile for which there is no dictionary created.
-    # The current loaded dictionary is the default profile one.
-    # As we have beem called to get the current profile dictionary and it still does not exist,
-    # We will create it now and pass the new, empty dictionary to the caller, but won't save it.
-    # This is a task the caller should do when and if they wish
-    dic = speechDictHandler.SpeechDict()
-    dic.create(os.path.join(WritePaths.speechDictsDir, profile.name, f"{type}.dic"))
-    log.debug(
-        f"{type} dictionary was requested for profile {profile.name}, but the backing file does not exist."
-        f" A New dictionary was created, set to be backed by {dic.fileName}"
-        + "if it is ever saved."
-    )
-    return dic
+	profile = config.conf.getActiveProfile()
+	if(type == "voice"):
+		return _getVoiceDictionary(profile)
+	# if we are om default profile or the specific dictionary profile is already loaded
+	if not profile.name or _hasDictionaryProfile(profile.name, f"{type}.dic"):
+		# we are with the correct dictionary loaded. Just return it.
+		log.debug(f"{type} dictionary, backed by {dictionaries[type].fileName} was requested")
+		return dictionaries[type]
+	# we are on a user profile for which there is no dictionary created.
+	# The current loaded dictionary is the default profile one.
+	# As we have beem called to get the current profile dictionary and it still does not exist,
+	# We will create it now and pass the new, empty dictionary to the caller, but won't save it.
+	# This is a task the caller should do when and if they wish
+	dic = speechDictHandler.SpeechDict()
+	dic.create(os.path.join(WritePaths.speechDictsDir, profile.name, f"{type}.dic"))
+	log.debug(
+		f"{type} dictionary was requested for profile {profile.name}, but the backing file does not exist."
+		f" A New dictionary was created, set to be backed by {dic.fileName}"
+		+ "if it is ever saved."
+	)
+	return dic
 
 
 def loadProfileDict():
-    profile = config.conf.getActiveProfile()
-    if _hasDictionaryProfile(profile.name, "default.dic"):
-        _loadProfileDictionary(dictionaries["default"], profile.name, "default.dic")
-    else:
-        dictionaries["default"].load(os.path.join(WritePaths.speechDictsDir, "default.dic"))
-    dictionaries["builtin"].load("builtin.dic")
+	profile = config.conf.getActiveProfile()
+	if _hasDictionaryProfile(profile.name, "default.dic"):
+		_loadProfileDictionary(dictionaries["default"], profile.name, "default.dic")
+	else:
+		dictionaries["default"].load(os.path.join(WritePaths.speechDictsDir, "default.dic"))
+	dictionaries["builtin"].load("builtin.dic")
 
 
 def loadVoiceDict(synth):
-    """Loads appropriate dictionary for the given synthesizer.
+	"""Loads appropriate dictionary for the given synthesizer.
 It handles case when the synthesizer doesn't support voice setting.
 """
-    dictionaryFileName = _getVoiceDictionaryFileName(synth)
-    profile = config.conf.getActiveProfile()
-    if(_hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFileName)):
-        _loadProfileVoiceDictionary(dictionaries["voice"], synth.name, dictionaryFileName)
-    else:
-        fileName = os.path.join(WritePaths.voiceDictsDir, synth.name, dictionaryFileName)
-        dictionaries["voice"].load(fileName)
+	dictionaryFileName = _getVoiceDictionaryFileName(synth)
+	profile = config.conf.getActiveProfile()
+	if(_hasVoiceDictionaryProfile(profile.name, synth.name, dictionaryFileName)):
+		_loadProfileVoiceDictionary(dictionaries["voice"], synth.name, dictionaryFileName)
+	else:
+		fileName = os.path.join(WritePaths.voiceDictsDir, synth.name, dictionaryFileName)
+		dictionaries["voice"].load(fileName)
 
 
 def _getVoiceDictionaryFileName(synth):
-    try:
-        dictFormatUpgrade.doAnyUpgrades(synth)
-    except Exception:
-        log.error("error trying to upgrade dictionaries", exc_info=True)
-        pass
-    if synth.isSupported("voice"):
-        voice = synth.availableVoices[synth.voice].displayName
-        baseName = dictFormatUpgrade.createVoiceDictFileName(synth.name, voice)
-    else:
-        baseName = r"{synth}.dic".format(synth=synth.name)
-    return baseName
+	try:
+		dictFormatUpgrade.doAnyUpgrades(synth)
+	except Exception:
+		log.error("error trying to upgrade dictionaries", exc_info=True)
+		pass
+	if synth.isSupported("voice"):
+		voice = synth.availableVoices[synth.voice].displayName
+		baseName = dictFormatUpgrade.createVoiceDictFileName(synth.name, voice)
+	else:
+		baseName = r"{synth}.dic".format(synth=synth.name)
+	return baseName
 
 
 def _hasDictionaryProfile(profileName, dictionaryName):
-    return os.path.exists(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
+	return os.path.exists(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
 
 
 def getProfileVoiceDictsPath():
-    profile = config.conf.getActiveProfile()
-    return os.path.join(WritePaths.speechDictsDir, profile.name or "", r"voiceDicts.v1")
+	profile = config.conf.getActiveProfile()
+	return os.path.join(WritePaths.speechDictsDir, profile.name or "", r"voiceDicts.v1")
 
 
 def _hasVoiceDictionaryProfile(profileName, synthName, voiceName):
-    return os.path.exists(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))
+	return os.path.exists(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))
 
 
 def _loadProfileDictionary(target, profileName, dictionaryName):
-    target.load(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
+	target.load(os.path.join(WritePaths.speechDictsDir, profileName or "", dictionaryName))
 
 
 def _loadProfileVoiceDictionary(target, synthName, voiceName):
-    target.load(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))
+	target.load(os.path.join(getProfileVoiceDictsPath(), synthName, voiceName))

--- a/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
@@ -46,7 +46,7 @@ def reloadDictionaries():
 	loadVoiceDict(synth)
 	profileName = config.conf.getActiveProfile().name
 
-	if profileConfigurationHelper.getSavedCheckboxValueForProfile():
+	if profileConfigurationHelper.getSavedKeepDictionaryUpdatedCheckboxValueForProfile():
 		sourceFileName = os.path.join(WritePaths.speechDictsDir, "default.dic")
 		source = speechDictHandler.SpeechDict()
 		source.load(sourceFileName)

--- a/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/dictHelper.py
@@ -41,6 +41,7 @@ def syncFrom(self, source):
 def reloadDictionaries():
     from synthDriverHandler import getSynth
     synth = getSynth()
+
     loadProfileDict()
     loadVoiceDict(synth)
     profileName = config.conf.getActiveProfile().name
@@ -55,6 +56,7 @@ def reloadDictionaries():
 
         voiceDict = getDictionary("voice")
         voiceDict.syncFrom(source)
+
         log.debug(f"Saving and activating updated dictionaries for profile {profileName}")
         for dictType in ["default", "voice"]:
             dictionaries[dictType].save()
@@ -102,7 +104,8 @@ def getDictionary(type):
     dic.create(os.path.join(WritePaths.speechDictsDir, profile.name, f"{type}.dic"))
     log.debug(
         f"{type} dictionary was requested for profile {profile.name}, but the backing file does not exist."
-        f" A New dictionary was created, set to be backed by {dic.fileName} if it is ever saved."
+        f" A New dictionary was created, set to be backed by {dic.fileName}"
+        + "if it is ever saved."
     )
     return dic
 

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -179,8 +179,8 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 				self.keepUpdatedCheckBox = wx.CheckBox(
 					self, label=_("&Sync entries with default profile dictionary.")
 				)
-				savedCheckboxValue = profileConfigurationHelper.getSavedCheckboxValueForProfile()
-				self.keepUpdatedCheckBox.SetValue(savedCheckboxValue)
+				savedKeepDictionaryUpdatedCheckboxValue = profileConfigurationHelper.getSavedKeepDictionaryUpdatedCheckboxValueForProfile()
+				self.keepUpdatedCheckBox.SetValue(savedKeepDictionaryUpdatedCheckboxValue)
 				sHelper.addItem(self.keepUpdatedCheckBox)
 
 	def hasEntry(self, pattern):

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -196,7 +196,7 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 		profileName = config.conf.getActiveProfile().name or "normal configuration"
 		if profileName != "normal configuration":
 			checkboxValue = self.keepUpdatedCheckBox.GetValue()
-			profileConfigurationHelper.saveCheckboxValueForProfile(checkboxValue)
+			profileConfigurationHelper.saveKeepDictionaryUpdatedCheckboxValueForProfile(checkboxValue)
 
 		if newDictionary:
 			# if we are saving a dictionary that didn't exist before (user just performed the first edition)

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -179,7 +179,9 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 				self.keepUpdatedCheckBox = wx.CheckBox(
 					self, label=_("&Sync entries with default profile dictionary.")
 				)
-				savedKeepDictionaryUpdatedCheckboxValue = profileConfigurationHelper.getSavedKeepDictionaryUpdatedCheckboxValueForProfile()
+				savedKeepDictionaryUpdatedCheckboxValue = (
+					profileConfigurationHelper.getSavedKeepDictionaryUpdatedCheckboxValueForProfile()
+				)
 				self.keepUpdatedCheckBox.SetValue(savedKeepDictionaryUpdatedCheckboxValue)
 				sHelper.addItem(self.keepUpdatedCheckBox)
 

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -172,15 +172,17 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 				label=_("&import entries from default profile dictionary")
 			).Bind(wx.EVT_BUTTON, self.onImportEntriesClick)
 
-		sHelper.addItem(bHelper)
+			sHelper.addItem(bHelper)
 
-		self.keepUpdatedCheckBox = wx.CheckBox(
-			self, label=_("Keep the default and current voice dictionary entries updated in this profile dictionary.")
-		)
-		savedCheckboxValue = profileConfigurationHelper.getSavedCheckboxValueForProfile()
-		self.keepUpdatedCheckBox.SetValue(savedCheckboxValue)
-		log.info("o valor da checkbox capturado é " + str(savedCheckboxValue))
-		sHelper.addItem(self.keepUpdatedCheckBox)
+			profile = config.conf.getActiveProfile()
+			if profile.name != "normal configuration":
+				self.keepUpdatedCheckBox = wx.CheckBox(
+					self, label=_("$Sync entries with default profile dictionary.")
+				)
+				savedCheckboxValue = profileConfigurationHelper.getSavedCheckboxValueForProfile()
+				self.keepUpdatedCheckBox.SetValue(savedCheckboxValue)
+				log.info("o valor da checkbox capturado é " + str(savedCheckboxValue))
+				sHelper.addItem(self.keepUpdatedCheckBox)
 
 	def hasEntry(self, pattern):
 		for row in range(self.dictList.GetItemCount()):

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -177,11 +177,10 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 			profile = config.conf.getActiveProfile()
 			if profile.name != "normal configuration":
 				self.keepUpdatedCheckBox = wx.CheckBox(
-					self, label=_("$Sync entries with default profile dictionary.")
+					self, label=_("&Sync entries with default profile dictionary.")
 				)
 				savedCheckboxValue = profileConfigurationHelper.getSavedCheckboxValueForProfile()
 				self.keepUpdatedCheckBox.SetValue(savedCheckboxValue)
-				log.info("o valor da checkbox capturado é " + str(savedCheckboxValue))
 				sHelper.addItem(self.keepUpdatedCheckBox)
 
 	def hasEntry(self, pattern):

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -105,7 +105,7 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 
 	def _makeTitle(self, title):
 		# Translators: The profile name for normal configuration
-		profileName = self._profile.name or "normal configuration"
+		profileName = self._profile.name or __("normal configuration")
 		return f"{title} - {profileName}"
 
 	def makeSettings(self, settingsSizer):
@@ -175,7 +175,7 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 			sHelper.addItem(bHelper)
 
 			profile = config.conf.getActiveProfile()
-			if profile.name != "normal configuration":
+			if profile.name != __("Normal configuration"):
 				self.keepUpdatedCheckBox = wx.CheckBox(
 					self, label=_("&Sync entries with default profile dictionary.")
 				)
@@ -195,10 +195,8 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 
 		profileName = config.conf.getActiveProfile().name or "normal configuration"
 		if profileName != "normal configuration":
-			log.info("profile is " + config.conf.getActiveProfile().name)
 			checkboxValue = self.keepUpdatedCheckBox.GetValue()
 			profileConfigurationHelper.saveCheckboxValueForProfile(checkboxValue)
-			log.info("salvo valor da checkbox:" + str(checkboxValue))
 
 		if newDictionary:
 			# if we are saving a dictionary that didn't exist before (user just performed the first edition)

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -7,9 +7,10 @@
 import addonHandler
 import config
 from . import dictHelper
+from logHandler import log
+from . import profileConfigurationHelper
 import gui
 from gui import guiHelper
-from logHandler import log
 import speechDictHandler
 import os
 import wx
@@ -84,12 +85,6 @@ def rebindMenu(menu, handler):
 
 def showEnhancedDictionaryDialog(dic, title=None):
 	gui.mainFrame.popupSettingsDialog(EnhancedDictionaryDialog, title or __("Default dictionary"), dic)
-
-
-def strToBool(string):
-	if string == "True":
-		return True
-	return False
 
 
 # This is our new dictionary dialog.
@@ -176,19 +171,15 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 				# Translators: The label for the import entries from default profile dictionary
 				label=_("&import entries from default profile dictionary")
 			).Bind(wx.EVT_BUTTON, self.onImportEntriesClick)
+
 		sHelper.addItem(bHelper)
+
 		self.keepUpdatedCheckBox = wx.CheckBox(
 			self, label=_("Keep the default and current voice dictionary entries updated in this profile dictionary.")
 		)
-		module = 'EnhancedDictionaries'
-		key = 'keepUpdatedCheckbox'
-		if module not in config.conf or key not in config.conf[module]:
-			config.conf[module] = {}
-			config.conf[module][key] = False
-			config.conf.save()
-		profileConfig = config.conf[module][key]
-		log.info('the config cauhth was' + str(profileConfig))
-		self.keepUpdatedCheckBox.SetValue(strToBool(profileConfig))
+		savedCheckboxValue = profileConfigurationHelper.getSavedCheckboxValueForProfile()
+		self.keepUpdatedCheckBox.SetValue(savedCheckboxValue)
+		log.info("o valor da checkbox capturado é " + str(savedCheckboxValue))
 		sHelper.addItem(self.keepUpdatedCheckBox)
 
 	def hasEntry(self, pattern):
@@ -201,11 +192,9 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 		newDictionary = not os.path.exists(self.speechDict.fileName)
 		super().onOk(evt)
 
-		module = 'EnhancedDictionaries'
-		key = 'keepUpdatedCheckbox'
-		config.conf[module][key] = self.keepUpdatedCheckBox.GetValue()
-		config.conf.save()
-		log.info('saved value from checkbox on config. It is ' + str(self.keepUpdatedCheckBox.GetValue()))
+		checkboxValue = self.keepUpdatedCheckBox.GetValue()
+		profileConfigurationHelper.saveCheckboxValueForProfile(checkboxValue)
+		log.info("salvo valor da checkbox:" + str(checkboxValue))
 
 		if newDictionary:
 			# if we are saving a dictionary that didn't exist before (user just performed the first edition)

--- a/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/guiHelper.py
@@ -194,9 +194,12 @@ class EnhancedDictionaryDialog(gui.speechDict.DictionaryDialog):
 		newDictionary = not os.path.exists(self.speechDict.fileName)
 		super().onOk(evt)
 
-		checkboxValue = self.keepUpdatedCheckBox.GetValue()
-		profileConfigurationHelper.saveCheckboxValueForProfile(checkboxValue)
-		log.info("salvo valor da checkbox:" + str(checkboxValue))
+		profileName = config.conf.getActiveProfile().name or "normal configuration"
+		if profileName != "normal configuration":
+			log.info("profile is " + config.conf.getActiveProfile().name)
+			checkboxValue = self.keepUpdatedCheckBox.GetValue()
+			profileConfigurationHelper.saveCheckboxValueForProfile(checkboxValue)
+			log.info("salvo valor da checkbox:" + str(checkboxValue))
 
 		if newDictionary:
 			# if we are saving a dictionary that didn't exist before (user just performed the first edition)

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -21,7 +21,7 @@ def getSavedKeepDictionaryUpdatedCheckboxValueForProfile():
 	return stringToBool(config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY])
 
 
-def saveCheckboxValueForProfile(value):
+def saveKeepDictionaryUpdatedCheckboxValueForProfile(value):
 	if module not in config.conf:
 		config.conf[module] = {}
 	if key not in config.conf[module]:

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -4,8 +4,9 @@ from logHandler import log
 module = 'EnhancedDictionaries'
 key = "keepUpdatedCheckbox"
 
+
 def stringToBool(value):
-    if value== "True":
+    if value == "True":
         return True
     return False
 

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -1,0 +1,31 @@
+import config
+from logHandler import log
+
+module = 'EnhancedDictionaries'
+key = "keepUpdatedCheckbox"
+
+def stringToBool(value):
+    if value== "True":
+        return True
+    return False
+
+
+def getSavedCheckboxValueForProfile():
+    if module not in config.conf:
+        log.info("o módulo não foi encontrado na configuração")
+        return False
+    if key not in config.conf[module]:
+        log.info("a chave não foi encontrada no módulo.")
+        return False
+    return stringToBool(config.conf[module][key])
+
+
+def saveCheckboxValueForProfile(value):
+    if module not in config.conf:
+        config.conf[module] = {}
+    if key not in config.conf[module]:
+        config.conf[module][key] = value
+        config.conf.save()
+    if config.conf[module][key] != value:
+        config.conf[module][key] = value
+        config.conf.save()

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -15,8 +15,8 @@ def getSavedCheckboxValueForProfile():
 	if module not in config.conf:
 		log.info("o módulo não foi encontrado na configuração")
 		return False
-	if key not in config.conf[module]:
-		log.info("a chave não foi encontrada no módulo.")
+	if KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY not in config.conf[module]:
+		log.info(f"{KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY} not found on {module}'s configuration")
 		return False
 	return stringToBool(config.conf[module][key])
 

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -6,27 +6,27 @@ key = "keepUpdatedCheckbox"
 
 
 def stringToBool(value):
-    if value == "True":
-        return True
-    return False
+	if value == "True":
+		return True
+	return False
 
 
 def getSavedCheckboxValueForProfile():
-    if module not in config.conf:
-        log.info("o módulo não foi encontrado na configuração")
-        return False
-    if key not in config.conf[module]:
-        log.info("a chave não foi encontrada no módulo.")
-        return False
-    return stringToBool(config.conf[module][key])
+	if module not in config.conf:
+		log.info("o módulo não foi encontrado na configuração")
+		return False
+	if key not in config.conf[module]:
+		log.info("a chave não foi encontrada no módulo.")
+		return False
+	return stringToBool(config.conf[module][key])
 
 
 def saveCheckboxValueForProfile(value):
-    if module not in config.conf:
-        config.conf[module] = {}
-    if key not in config.conf[module]:
-        config.conf[module][key] = value
-        config.conf.save()
-    if config.conf[module][key] != value:
-        config.conf[module][key] = value
-        config.conf.save()
+	if module not in config.conf:
+		config.conf[module] = {}
+	if key not in config.conf[module]:
+		config.conf[module][key] = value
+		config.conf.save()
+	if config.conf[module][key] != value:
+		config.conf[module][key] = value
+		config.conf.save()

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -11,7 +11,7 @@ def stringToBool(value):
 	return False
 
 
-def getSavedCheckboxValueForProfile():
+def getSavedKeepDictionaryUpdatedCheckboxValueForProfile():
 	if module not in config.conf:
 		log.info("o módulo não foi encontrado na configuração")
 		return False

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -27,6 +27,6 @@ def saveCheckboxValueForProfile(value):
 	if key not in config.conf[module]:
 		config.conf[module][key] = value
 		config.conf.save()
-	if config.conf[module][key] != value:
-		config.conf[module][key] = value
+	if config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] != value:
+		config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] = value
 		config.conf.save()

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -13,7 +13,7 @@ def stringToBool(value):
 
 def getSavedKeepDictionaryUpdatedCheckboxValueForProfile():
 	if module not in config.conf:
-		log.info("o módulo não foi encontrado na configuração")
+		log.debug(f"{module} not found on profile's configuration file")
 		return False
 	if KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY not in config.conf[module]:
 		log.info(f"{KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY} not found on {module}'s configuration")

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -2,7 +2,7 @@ import config
 from logHandler import log
 
 module = 'EnhancedDictionaries'
-key = "keepUpdatedCheckbox"
+KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY = "keepUpdatedCheckbox"
 
 
 def stringToBool(value):
@@ -26,7 +26,6 @@ def saveKeepDictionaryUpdatedCheckboxValueForProfile(value):
 		config.conf[module] = {}
 	if KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY not in config.conf[module]:
 		config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] = value
-		```
 		config.conf.save()
 	if config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] != value:
 		config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] = value

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -18,7 +18,7 @@ def getSavedKeepDictionaryUpdatedCheckboxValueForProfile():
 	if KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY not in config.conf[module]:
 		log.info(f"{KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY} not found on {module}'s configuration")
 		return False
-	return stringToBool(config.conf[module][key])
+	return stringToBool(config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY])
 
 
 def saveCheckboxValueForProfile(value):

--- a/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
+++ b/addon/globalPlugins/EnhancedDictionaries/profileConfigurationHelper.py
@@ -24,8 +24,9 @@ def getSavedKeepDictionaryUpdatedCheckboxValueForProfile():
 def saveKeepDictionaryUpdatedCheckboxValueForProfile(value):
 	if module not in config.conf:
 		config.conf[module] = {}
-	if key not in config.conf[module]:
-		config.conf[module][key] = value
+	if KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY not in config.conf[module]:
+		config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] = value
+		```
 		config.conf.save()
 	if config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] != value:
 		config.conf[module][KEEP_DICTIONARY_UPDATED_CONFIGURATION_KEY] = value


### PR DESCRIPTION
The purpose o this pr is to add a feature that import the entries from default ou current voice dictionary whenever it is loaded according to the user`s desire.
It was added a checkbox on the profile dictionary dialog, where the user can enable or disable the feature.
The choice is written to the profile`s ini file when the user click the ok button. The next time the dialog is opened, the written value will be used to determine if the checkbox is checked.
Similarly, the reload dictionaries function from dictHelper will check the profile`s ini configuration file to determine if it needs to perform a new importing from default and current voice dictionaries.
The advantage is to have the profile dict updated with default and voice ones, so that the user do not need to update it manually.