### PR TITLE
Fix fork PR resolution in artifact comment workflow

### DIFF
--- a/.github/workflows/comment-pr-artifact.yml
+++ b/.github/workflows/comment-pr-artifact.yml
@@ -31,14 +31,34 @@ jobs:
                           || `${context.serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
                       const conclusion = workflowRun.conclusion || 'unknown';
 
-                      // workflow_run.pull_requests is empty for fork PRs, so
-                      // resolve the PR from the head commit instead.
-                      const associated = await github.paginate(
-                          github.rest.repos.listPullRequestsAssociatedWithCommit,
-                          { owner, repo, commit_sha: commitSha },
-                      );
-                      const pullRequest = associated.find((pr) => pr.state === 'open')
-                          || associated[0];
+                      // workflow_run.pull_requests is empty for fork PRs, and
+                      // listPullRequestsAssociatedWithCommit does not resolve a
+                      // fork's head commit either. Searching open PRs by the
+                      // head repo owner + branch is the reliable path for forks.
+                      const headBranch = workflowRun.head_branch;
+                      const headOwner = workflowRun.head_repository?.owner?.login;
+
+                      let pullRequest = null;
+                      if (headOwner && headBranch) {
+                          const openPrs = await github.paginate(github.rest.pulls.list, {
+                              owner,
+                              repo,
+                              state: 'open',
+                              head: `${headOwner}:${headBranch}`,
+                              per_page: 100,
+                          });
+                          pullRequest = openPrs.find((pr) => pr.head.sha === commitSha)
+                              || openPrs[0];
+                      }
+                      if (!pullRequest) {
+                          // Fallback for same-repo PRs.
+                          const associated = await github.paginate(
+                              github.rest.repos.listPullRequestsAssociatedWithCommit,
+                              { owner, repo, commit_sha: commitSha },
+                          );
+                          pullRequest = associated.find((pr) => pr.state === 'open')
+                              || associated[0];
+                      }
 
                       if (!pullRequest) {
                           core.info(`No pull request found for commit ${shortSha}.`);


### PR DESCRIPTION
Follow-up to #25. The unified artifact comment merged in #25 still does not post on fork PRs.

## Problem
`comment-pr-artifact.yml` resolved the PR from the head commit via `listPullRequestsAssociatedWithCommit`. That endpoint does **not** resolve a fork's head commit to its PR, so the job logged `No pull request found for commit …` and returned without commenting. Observed on the run triggered by #21's green PR Checks — the comment job succeeded but posted nothing.

## Fix
Resolve the PR by searching open PRs by `${head_repo_owner}:${head_branch}` (both available on the `workflow_run` payload), matching on head SHA. This is the reliable path for fork PRs. The commit-association lookup is kept as a fallback for same-repo PRs.

Verified against #21: `GET /pulls?state=open&head=surfer0627:fix-dict-gestures-route-to-enhanced` returns PR #21 with the matching head SHA.

## Note
`workflow_run` runs the workflow copy from the **default branch**, so this only takes effect once merged. After merge, re-running #21's PR Checks (or the next fork-PR build) should post the unified comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)